### PR TITLE
fix:duplicate condition in limit removal logic

### DIFF
--- a/src/limits.c
+++ b/src/limits.c
@@ -145,8 +145,8 @@ removeLimit(Limit *limit){
         /*Limit has only left child*/
         replaceLimitInParent(limit, limit->leftChild);
     }
-    else if(limit->leftChild != NULL && limit->rightChild == NULL){
-        /*Limit has only left child*/
+    else if (limit->leftChild == NULL && limit->rightChild != NULL) {
+        /*Limit has only right child*/
         replaceLimitInParent(limit, limit->rightChild);
     }
     else{


### PR DESCRIPTION
Corrected the duplicate condition in the limit removal logic where both conditions were checking for the presence of the left child and absence of the right child. 

Updated one condition to check for the presence of the right child and absence of the left child.